### PR TITLE
Change Okey to OK in AlertView

### DIFF
--- a/scripts/pages/tabs/chatbot/chatbotPg.js
+++ b/scripts/pages/tabs/chatbot/chatbotPg.js
@@ -221,9 +221,9 @@ function initAlerView() {
 
   inforAlertView.addButton({
     index: AlertView.ButtonType.POSITIVE,
-    text: "Okey",
+    text: "OK",
     onClick: function() {
-      console.log("Okey clicked.");
+      console.log("OK clicked.");
     }
   });
 


### PR DESCRIPTION
'OK' or 'Okay' usage is more popular than 'Okey'. I suggest to use 'OK' wherever appropriate instead of 'Okay' or 'Okey'. 